### PR TITLE
Add a Student Repertoire Table

### DIFF
--- a/controllers/pieces.controller.js
+++ b/controllers/pieces.controller.js
@@ -188,12 +188,12 @@ exports.findLanguage = (req, res) => {
 };
 
 //Find a piece based on the repertoire id
-exports.findRepertoireId = (req, res) => {
+exports.findStudentRepertoireId = (req, res) => {
   const { page, size } = req.query;
   const { limit, offset } = getPagination(page, size);
-  const repertoireId = req.params.repertoireId;
+  const studentrepertoireId = req.params.studentrepertoireId;
   Pieces.findAndCountAll({
-    where: { repertoireId: repertoireId },
+    where: { studentrepertoireId: studentrepertoireId },
     limit,
     offset,
   })

--- a/controllers/pieces.controller.js
+++ b/controllers/pieces.controller.js
@@ -188,12 +188,12 @@ exports.findLanguage = (req, res) => {
 };
 
 //Find a piece based on the repertoire id
-exports.findStudentRepertoireId = (req, res) => {
+exports.findRepertoireId = (req, res) => {
   const { page, size } = req.query;
   const { limit, offset } = getPagination(page, size);
-  const studentrepertoireId = req.params.studentrepertoireId;
+  const repertoireId = req.params.repertoireId;
   Pieces.findAndCountAll({
-    where: { studentrepertoireId: studentrepertoireId },
+    where: { repertoireId: repertoireId },
     limit,
     offset,
   })

--- a/controllers/repertoire.controller.js
+++ b/controllers/repertoire.controller.js
@@ -48,6 +48,33 @@ exports.findAll = (req, res) => {
     });
 };
 
+// Find a repertoire based on the instrument id
+exports.findRepertoireByInstrument = (req, res) => {
+  const { page, size } = req.query;
+  const { limit, offset } = getPagination(page, size);
+  const instrumentId = req.params.instrumentId;
+  Repertoire.findAndCountAll({
+    where: { instrumentId: instrumentId },
+    limit,
+    offset,
+  })
+    .then((data) => {
+      if (data) {
+        const response = getPagingData(data, page, limit);
+        res.send(response);
+      } else {
+        res.status(404).send({
+          message: `Not Found`,
+        });
+      }
+    })
+    .catch((err) => {
+      res.status(500).send({
+        message: "Error",
+      });
+    });
+};
+
 //Update repertoire using the id
 exports.update = (req, res) => {
   const id = req.params.id;

--- a/controllers/repertoire.controller.js
+++ b/controllers/repertoire.controller.js
@@ -48,23 +48,20 @@ exports.findAll = (req, res) => {
     });
 };
 
-//Find repertoire based on student info id
-exports.findStudentId = (req, res) => {
-  const { page, size } = req.query;
-  const { limit, offset } = getPagination(page, size);
-  const studentId = req.params.studentId;
-  Repertoire.findAndCountAll({
-    where: { studentId: studentId },
-    limit,
-    offset,
+//Update repertoire using the id
+exports.update = (req, res) => {
+  const id = req.params.id;
+  Repertoire.update(req.body, {
+    where: { id: id },
   })
-    .then((data) => {
-      if (data) {
-        const response = getPagingData(data, page, limit);
-        res.send(response);
+    .then((num) => {
+      if (num == 1) {
+        res.send({
+          message: "Repertoire was updated successfully.",
+        });
       } else {
-        res.status(404).send({
-          message: `Not Found`,
+        res.send({
+          message: `Cannot update repertoire with id=${id}. Maybe repertoire was not found or req.body is empty!`,
         });
       }
     })

--- a/controllers/studentrepertoire.controller.js
+++ b/controllers/studentrepertoire.controller.js
@@ -19,7 +19,6 @@ const getPagingData = (data, page, limit) => {
 exports.create = (req, res) => {
   const studentrepertoire = {
     studentId: req.body.studentId,
-    instrumentId: req.body.instrumentId,
     repertoireId: req.body.repertoireId,
   };
 
@@ -57,33 +56,6 @@ exports.findStudentRepertoireByStudent = (req, res) => {
   const studentId = req.params.studentId;
   StudentRepertoire.findAndCountAll({
     where: { studentId: studentId },
-    limit,
-    offset,
-  })
-    .then((data) => {
-      if (data) {
-        const response = getPagingData(data, page, limit);
-        res.send(response);
-      } else {
-        res.status(404).send({
-          message: `Not Found`,
-        });
-      }
-    })
-    .catch((err) => {
-      res.status(500).send({
-        message: "Error",
-      });
-    });
-};
-
-// Find a student repertoire based on the instrument id
-exports.findStudentRepertoireByInstrument = (req, res) => {
-  const { page, size } = req.query;
-  const { limit, offset } = getPagination(page, size);
-  const instrumentId = req.params.instrumentId;
-  StudentRepertoire.findAndCountAll({
-    where: { instrumentId: instrumentId },
     limit,
     offset,
   })

--- a/controllers/studentrepertoire.controller.js
+++ b/controllers/studentrepertoire.controller.js
@@ -1,0 +1,180 @@
+const db = require("../models");
+const StudentRepertoire = db.studentrepertoire;
+const Op = db.Sequelize.Op;
+
+//Functions for the pagination
+const getPagination = (page, size) => {
+  const limit = size ? +size : 25;
+  const offset = page ? page * limit : 0;
+  return { limit, offset };
+};
+const getPagingData = (data, page, limit) => {
+  const { count: totalItems, rows: StudentRepertoire } = data;
+  const currentPage = page ? +page : 0;
+  const totalPages = Math.ceil(totalItems / limit);
+  return { totalItems, StudentRepertoire, totalPages, currentPage };
+};
+
+//Add an studentrepertoire to the database
+exports.create = (req, res) => {
+  const studentrepertoire = {
+    studentId: req.body.studentId,
+    instrumentId: req.body.instrumentId,
+    repertoireId: req.body.repertoireId,
+  };
+
+  StudentRepertoire.create(studentrepertoire)
+    .then((data) => {
+      res.send(data);
+    })
+    .catch((err) => {
+      res.status(500).send({
+        message: err.message || "Some error occurred, try again later!",
+      });
+    });
+};
+
+//Get a list of all of the studentrepertoires in the database
+exports.findAll = (req, res) => {
+  const { page, size } = req.query;
+  const { limit, offset } = getPagination(page, size);
+  StudentRepertoire.findAndCountAll({ limit, offset })
+    .then((data) => {
+      const response = getPagingData(data, page, limit);
+      res.send(response);
+    })
+    .catch((err) => {
+      res.status(500).send({
+        message: err.message || "Something happend, try again!",
+      });
+    });
+};
+
+//Find student repertoire based on student id
+exports.findStudentRepertoireByStudent = (req, res) => {
+  const { page, size } = req.query;
+  const { limit, offset } = getPagination(page, size);
+  const studentId = req.params.studentId;
+  StudentRepertoire.findAndCountAll({
+    where: { studentId: studentId },
+    limit,
+    offset,
+  })
+    .then((data) => {
+      if (data) {
+        const response = getPagingData(data, page, limit);
+        res.send(response);
+      } else {
+        res.status(404).send({
+          message: `Not Found`,
+        });
+      }
+    })
+    .catch((err) => {
+      res.status(500).send({
+        message: "Error",
+      });
+    });
+};
+
+// Find a student repertoire based on the instrument id
+exports.findStudentRepertoireByInstrument = (req, res) => {
+  const { page, size } = req.query;
+  const { limit, offset } = getPagination(page, size);
+  const instrumentId = req.params.instrumentId;
+  StudentRepertoire.findAndCountAll({
+    where: { instrumentId: instrumentId },
+    limit,
+    offset,
+  })
+    .then((data) => {
+      if (data) {
+        const response = getPagingData(data, page, limit);
+        res.send(response);
+      } else {
+        res.status(404).send({
+          message: `Not Found`,
+        });
+      }
+    })
+    .catch((err) => {
+      res.status(500).send({
+        message: "Error",
+      });
+    });
+};
+
+// Find a student repertoire based on the repertoire id
+exports.findStudentRepertoireByRepertoire = (req, res) => {
+  const { page, size } = req.query;
+  const { limit, offset } = getPagination(page, size);
+  const repertoireId = req.params.repertoireId;
+  StudentRepertoire.findAndCountAll({
+    where: { repertoireId: repertoireId },
+    limit,
+    offset,
+  })
+    .then((data) => {
+      if (data) {
+        const response = getPagingData(data, page, limit);
+        res.send(response);
+      } else {
+        res.status(404).send({
+          message: `Not Found`,
+        });
+      }
+    })
+    .catch((err) => {
+      res.status(500).send({
+        message: "Error",
+      });
+    });
+};
+
+//Update student repertoire using the id
+exports.update = (req, res) => {
+  const id = req.params.id;
+  StudentRepertoire.update(req.body, {
+    where: { id: id },
+  })
+    .then((num) => {
+      if (num == 1) {
+        res.send({
+          message: "Student Repertoire was updated successfully.",
+        });
+      } else {
+        res.send({
+          message: `Cannot update student repertoire with id=${id}. Maybe repertoire was not found or req.body is empty!`,
+        });
+      }
+    })
+    .catch((err) => {
+      res.status(500).send({
+        message: "Error",
+      });
+    });
+};
+
+//Delete studentrepertoire using the id
+exports.delete = (req, res) => {
+  const id = req.params.id;
+  StudentRepertoire.destroy({
+    where: { id: id },
+  })
+    .then((num) => {
+      if (num == 1) {
+        res.send({
+          message: "StudentRepertoire was deleted successfully!",
+        });
+      } else {
+        res.send({
+          message: `Cannot delete studentrepertoire with id=${id}. Maybe studentrepertoire was not found!`,
+        });
+      }
+    })
+    .catch((err) => {
+      res.status(500).send({
+        message: "Could not delete",
+      });
+    });
+};

--- a/models/foreignkeys.js
+++ b/models/foreignkeys.js
@@ -55,7 +55,7 @@ function addForeignKeys(db) {
   members.belongsTo(ensemble);
 
   pieces.belongsTo(composers);
-  pieces.belongsTo(studentrepertoire);
+  pieces.belongsTo(repertoire);
   composers.hasMany(pieces);
 
   session.belongsTo(users);
@@ -80,7 +80,7 @@ function addForeignKeys(db) {
 
   studentrepertoire.belongsTo(students);
   studentrepertoire.belongsTo(repertoire);
-  studentrepertoire.belongsTo(instruments);
+  repertoire.belongsTo(instruments);
 
   userrole.belongsTo(roles);
   userrole.belongsTo(users);

--- a/models/foreignkeys.js
+++ b/models/foreignkeys.js
@@ -21,6 +21,7 @@ function addForeignKeys(db) {
   const students = db.students;
   const studentaccompanist = db.studentaccompanist;
   const studentinstructor = db.studentinstructor;
+  const studentrepertoire = db.studentrepertoire;
   const userrole = db.userrole;
   const users = db.users;
 
@@ -54,11 +55,8 @@ function addForeignKeys(db) {
   members.belongsTo(ensemble);
 
   pieces.belongsTo(composers);
-  pieces.belongsTo(repertoire);
+  pieces.belongsTo(studentrepertoire);
   composers.hasMany(pieces);
-  repertoire.hasMany(pieces);
-
-  repertoire.belongsTo(students);
 
   session.belongsTo(users);
 
@@ -68,12 +66,10 @@ function addForeignKeys(db) {
 
   students.belongsTo(users);
   students.belongsTo(members);
-  students.belongsTo(repertoire);
   students.belongsTo(requirements);
 
   students.hasMany(studentinstructor, { as: "instructors" });
   students.hasMany(studentaccompanist, { as: "accompanists" });
-  students.hasMany(repertoire);
 
   studentinstructor.belongsTo(students);
   studentinstructor.belongsTo(instructors);
@@ -81,6 +77,10 @@ function addForeignKeys(db) {
 
   studentinstruments.belongsTo(instruments);
   studentinstruments.belongsTo(students);
+
+  studentrepertoire.belongsTo(students);
+  studentrepertoire.belongsTo(repertoire);
+  studentrepertoire.belongsTo(instruments);
 
   userrole.belongsTo(roles);
   userrole.belongsTo(users);

--- a/models/index.js
+++ b/models/index.js
@@ -50,6 +50,10 @@ db.studentinstruments = require("./studentinstruments.model.js")(
   sequelize,
   Sequelize
 );
+db.studentrepertoire = require("./studentrepertoire.model.js")(
+  sequelize,
+  Sequelize
+);
 db.userrole = require("./userrole.model.js")(sequelize, Sequelize);
 db.users = require("./users.model.js")(sequelize, Sequelize);
 

--- a/models/studentrepertoire.model.js
+++ b/models/studentrepertoire.model.js
@@ -1,0 +1,13 @@
+const { SqlError } = require("mariadb");
+
+module.exports = (sequelize, Sequelize) => {
+  const StudentRepertoire = sequelize.define("studentrepertoire", {
+    id: {
+      type: Sequelize.INTEGER,
+      autoIncrement: true,
+      primaryKey: true,
+      unique: true,
+    },
+  });
+  return StudentRepertoire;
+};

--- a/routes/routes.js
+++ b/routes/routes.js
@@ -265,9 +265,9 @@ module.exports = (app) => {
   );
   router.get("/pieces/language/:language", [authenticate], pieces.findLanguage);
   router.get(
-    "/pieces/studentrepertoireid/:studentrepertoireId",
+    "/pieces/repertoireid/:repertoireId",
     [authenticate],
-    pieces.findStudentRepertoireId
+    pieces.findRepertoireId
   );
   router.delete("/pieces/:id", [authenticate], pieces.delete);
 
@@ -275,6 +275,11 @@ module.exports = (app) => {
   router.post("/repertoire", [authenticate], repertoire.create);
   router.put("/repertoire/:id", [authenticate], repertoire.update);
   router.get("/repertoire", [authenticate], repertoire.findAll);
+  router.get(
+    "/repertoire/instrumentId/:instrumentId",
+    [authenticate],
+    studentrepertoire.findRepertoireByInstrument
+  );
   router.delete("/repertoire/:id", [authenticate], repertoire.delete);
 
   // Requirements
@@ -410,11 +415,6 @@ module.exports = (app) => {
     "/studentrepertoire/repertoireId/:repertoireId",
     [authenticate],
     studentrepertoire.findStudentRepertoireByRepertoire
-  );
-  router.get(
-    "/studentrepertoire/instrumentId/:instrumentId",
-    [authenticate],
-    studentrepertoire.findStudentRepertoireByInstrument
   );
   router.delete(
     "/studentrepertoire/:id",

--- a/routes/routes.js
+++ b/routes/routes.js
@@ -24,6 +24,7 @@ module.exports = (app) => {
   const userrole = require("../controllers/userrole.controller.js");
   const users = require("../controllers/users.controller.js");
   const students = require("../controllers/students.controller.js");
+  const studentrepertoire = require("../controllers/studentrepertoire.controller.js");
   const { authenticate } = require("../authorization/authorization.js");
 
   var router = require("express").Router();
@@ -264,20 +265,16 @@ module.exports = (app) => {
   );
   router.get("/pieces/language/:language", [authenticate], pieces.findLanguage);
   router.get(
-    "/pieces/repertoireid/:repertoireId",
+    "/pieces/studentrepertoireid/:studentrepertoireId",
     [authenticate],
-    pieces.findRepertoireId
+    pieces.findStudentRepertoireId
   );
   router.delete("/pieces/:id", [authenticate], pieces.delete);
 
   // Repertoire
   router.post("/repertoire", [authenticate], repertoire.create);
+  router.put("/repertoire/:id", [authenticate], repertoire.update);
   router.get("/repertoire", [authenticate], repertoire.findAll);
-  router.get(
-    "/repertoire/studentid/:studentId",
-    [authenticate],
-    repertoire.findStudentId
-  );
   router.delete("/repertoire/:id", [authenticate], repertoire.delete);
 
   // Requirements
@@ -394,6 +391,35 @@ module.exports = (app) => {
     "/studentinstruments/:id",
     [authenticate],
     studentinstruments.delete
+  );
+
+  // Student Repertoire
+  router.post("/studentrepertoire", [authenticate], studentrepertoire.create);
+  router.put(
+    "/studentrepertoire/:id",
+    [authenticate],
+    studentrepertoire.update
+  );
+  router.get("/studentrepertoire", [authenticate], studentrepertoire.findAll);
+  router.get(
+    "/studentrepertoire/studentId/:studentId",
+    [authenticate],
+    studentrepertoire.findStudentRepertoireByStudent
+  );
+  router.get(
+    "/studentrepertoire/repertoireId/:repertoireId",
+    [authenticate],
+    studentrepertoire.findStudentRepertoireByRepertoire
+  );
+  router.get(
+    "/studentrepertoire/instrumentId/:instrumentId",
+    [authenticate],
+    studentrepertoire.findStudentRepertoireByInstrument
+  );
+  router.delete(
+    "/studentrepertoire/:id",
+    [authenticate],
+    studentrepertoire.delete
   );
 
   // User Roles


### PR DESCRIPTION
Adds a student repertoire table to allow for students to have more than one repertoire.

- Adds a studentrepertoire model for the table
- Adds the studentrepertoire to the index
- Adds a studentrepertoire controller
- Edits the controller for the pieces table
- Edits the controller for the repertoire table
- Adds foreign keys to the studentrepertoire table
- Edits the foreign keys for the pieces table
- Edits the foreign keys for the repertoire table
- Adds the routes for the student repertoire table
- Edits the routes for the pieces table
- Edits the routes for the repertoire table