### PR TITLE
Instructor Add Availability and Student Signup Filter by Instructor Availability

### DIFF
--- a/controllers/availability.controller.js
+++ b/controllers/availability.controller.js
@@ -1,5 +1,6 @@
 const db = require("../models");
 const Availability = db.availability;
+const Event = db.event;
 const Op = db.Sequelize.Op;
 
 //Functions for the pagination
@@ -54,9 +55,9 @@ exports.findAll = (req, res) => {
 exports.findInstructorId = (req, res) => {
   const { page, size } = req.query;
   const { limit, offset } = getPagination(page, size);
-  const instructorid = req.params.instructorid;
+  const instructorId = req.params.instructorId;
   Availability.findAndCountAll({
-    where: { instructorId: instructorid },
+    where: { instructorId: instructorId },
     limit,
     offset,
   })
@@ -73,6 +74,42 @@ exports.findInstructorId = (req, res) => {
     .catch((err) => {
       res.status(500).send({
         message: "Error",
+      });
+    });
+};
+
+//Find availability based on a specific instructorId and eventId
+exports.findInstructorAndEvent = (req, res) => {
+  const { page, size } = req.query;
+  const { limit, offset } = getPagination(page, size);
+  const instructorId = req.params.instructorId;
+  const eventId = req.params.eventId;
+  Availability.findAndCountAll({
+    where: { instructorId: instructorId, eventId: eventId },
+    attributes: [
+      ["id", "availabilityId"],
+      ["starttime", "startTime"],
+      ["endtime", "endTime"],
+      "instructorId",
+      "eventId",
+    ],
+    include: { model: Event, attributes: [["date", "eventDate"]] },
+    limit,
+    offset,
+  })
+    .then((data) => {
+      if (data) {
+        const response = getPagingData(data, page, limit);
+        res.send(response);
+      } else {
+        res.status(404).send({
+          message: `Not Found`,
+        });
+      }
+    })
+    .catch((err) => {
+      res.status(500).send({
+        message: "Error" + err,
       });
     });
 };

--- a/controllers/availability.controller.js
+++ b/controllers/availability.controller.js
@@ -19,9 +19,10 @@ const getPagingData = (data, page, limit) => {
 //Add availability to the database
 exports.create = (req, res) => {
   const availability = {
-    datetimestart: req.body.datetimestart,
-    datetimeend: req.body.datetimeend,
-    instructorId: req.body.instructorId,
+    starttime: req.body.starttime,
+    endtime: req.body.endtime,
+    userId: req.body.userId,
+    eventId: req.body.eventId,
   };
 
   Availability.create(availability)
@@ -79,18 +80,18 @@ exports.findInstructorId = (req, res) => {
 };
 
 //Find availability based on a specific instructorId and eventId
-exports.findInstructorAndEvent = (req, res) => {
+exports.findUserAndEvent = (req, res) => {
   const { page, size } = req.query;
   const { limit, offset } = getPagination(page, size);
-  const instructorId = req.params.instructorId;
+  const userId = req.params.userId;
   const eventId = req.params.eventId;
   Availability.findAndCountAll({
-    where: { instructorId: instructorId, eventId: eventId },
+    where: { userId: userId, eventId: eventId },
     attributes: [
       ["id", "availabilityId"],
       ["starttime", "startTime"],
       ["endtime", "endTime"],
-      "instructorId",
+      "userId",
       "eventId",
     ],
     include: { model: Event, attributes: [["date", "eventDate"]] },

--- a/controllers/instructors.controller.js
+++ b/controllers/instructors.controller.js
@@ -1,5 +1,6 @@
 const db = require("../models");
 const Instructors = db.instructors;
+const Instructor = require("../utils/instructor.js");
 const Op = db.Sequelize.Op;
 
 //Functions for the pagination
@@ -46,6 +47,25 @@ exports.findAll = (req, res) => {
     .catch((err) => {
       res.status(500).send({
         message: err.message || "Something happend, try again!",
+      });
+    });
+};
+
+//Get a list of all of the instructorss in the database
+exports.findAllInfo = async (req, res) => {
+  await Instructor.getAllInstructorDataForUserId(req.params.id)
+    .then((data) => {
+      if (data) {
+        res.send(data);
+      } else {
+        res.status(404).send({
+          message: `Not Found` + data,
+        });
+      }
+    })
+    .catch((err) => {
+      res.status(500).send({
+        message: "Error" + err,
       });
     });
 };

--- a/models/availability.model.js
+++ b/models/availability.model.js
@@ -2,11 +2,11 @@ const { SqlError } = require("mariadb");
 
 module.exports = (sequelize, Sequelize) => {
   const Availability = sequelize.define("availability", {
-    datetimestart: {
-      type: Sequelize.DATE,
+    starttime: {
+      type: Sequelize.TIME,
     },
-    datetimeend: {
-      type: Sequelize.DATE,
+    endtime: {
+      type: Sequelize.TIME,
     },
     id: {
       type: Sequelize.INTEGER,

--- a/models/foreignkeys.js
+++ b/models/foreignkeys.js
@@ -26,6 +26,7 @@ function addForeignKeys(db) {
   const users = db.users;
 
   availability.belongsTo(instructors);
+  availability.belongsTo(event);
 
   critiques.belongsTo(eventsignup);
 
@@ -53,10 +54,12 @@ function addForeignKeys(db) {
 
   event.hasMany(eventsignup, { as: "signups" });
   event.hasMany(eventtime, { as: "times" });
+  event.hasMany(availability);
 
   instructors.belongsTo(users);
   instructors.hasMany(eventsignupjuror);
   instructors.hasMany(studentinstructor);
+  instructors.hasMany(availability, { as: "availabilities" });
 
   users.hasMany(instructors);
   users.hasMany(accompanists);

--- a/models/foreignkeys.js
+++ b/models/foreignkeys.js
@@ -25,7 +25,7 @@ function addForeignKeys(db) {
   const userrole = db.userrole;
   const users = db.users;
 
-  availability.belongsTo(instructors);
+  availability.belongsTo(users);
   availability.belongsTo(event);
 
   critiques.belongsTo(eventsignup);
@@ -59,10 +59,10 @@ function addForeignKeys(db) {
   instructors.belongsTo(users);
   instructors.hasMany(eventsignupjuror);
   instructors.hasMany(studentinstructor);
-  instructors.hasMany(availability, { as: "availabilities" });
 
   users.hasMany(instructors);
   users.hasMany(accompanists);
+  users.hasMany(availability);
 
   accompanists.belongsTo(users);
   accompanists.hasMany(studentaccompanist);

--- a/routes/routes.js
+++ b/routes/routes.js
@@ -63,9 +63,9 @@ module.exports = (app) => {
     availability.findInstructorId
   );
   router.get(
-    "/availability/getByInstructorAndEvent/:instructorId/:eventId",
+    "/availability/getByUserAndEvent/:userId/:eventId",
     [authenticate],
-    availability.findInstructorAndEvent
+    availability.findUserAndEvent
   );
   router.get(
     "/availability/startdate/:startdate",
@@ -221,6 +221,12 @@ module.exports = (app) => {
   router.post("/instructors", [authenticate], instructors.create);
   router.put("/instructors/:id", [authenticate], instructors.update);
   router.get("/instructors", [authenticate], instructors.findAll);
+  router.get(
+    "/instructors/allInfo/:id",
+    [authenticate],
+    instructors.findAllInfo
+  );
+
   router.get(
     "/instructors/userid/:userid",
     [authenticate],

--- a/routes/routes.js
+++ b/routes/routes.js
@@ -63,6 +63,11 @@ module.exports = (app) => {
     availability.findInstructorId
   );
   router.get(
+    "/availability/getByInstructorAndEvent/:instructorId/:eventId",
+    [authenticate],
+    availability.findInstructorAndEvent
+  );
+  router.get(
     "/availability/startdate/:startdate",
     [authenticate],
     availability.findStartDate

--- a/utils/instructor.js
+++ b/utils/instructor.js
@@ -1,0 +1,44 @@
+const db = require("../models");
+const Students = db.students;
+const Instructors = db.instructors;
+const Users = db.users;
+const Availability = db.availability;
+const StudentInstructor = db.studentinstructor;
+
+exports.getAllInstructorDataForUserId = async (userId) => {
+  const ins = await Instructors.findAll({
+    where: { userId: userId },
+    attributes: [["id", "instructorId"], "title", "createdAt", "updatedAt"],
+    include: [
+      {
+        model: Users,
+        attributes: [["id", "userId"]],
+        include: {
+          model: Availability,
+          attributes: [
+            ["id", "availabilityId"],
+            "eventId",
+            "starttime",
+            "endtime",
+          ],
+        },
+      },
+      {
+        model: StudentInstructor,
+        attributes: [["id", "studentInstructorId"]],
+        include: {
+          model: Students,
+          attributes: [
+            ["id", "studentId"],
+            "level",
+            "major",
+            "classification",
+            "semesters",
+            "userId",
+          ],
+        },
+      },
+    ],
+  });
+  return ins;
+};


### PR DESCRIPTION
Adds the ability for an instructor to add their availability, and for a student to filter timeslots on a signup by their instructor's availability.

Frontend PR for this as well.

**NEW** Instructor UserStore getAll:
New instructor userRoleInfo object looks as follows:
```
{
  "instructorId": 2,
  "title": "Private Instructor",
  "createdAt": "2023-04-05T11:06:02.000Z",
  "updatedAt": "2023-04-05T11:06:02.000Z",
  "availabilities": [
    {
      "availabilityId": 9,
      "eventId": 2,
      "starttime": "09:00:00",
      "endtime": "10:00:00"
    },
    {
      "availabilityId": 11,
      "eventId": 2,
      "starttime": "13:00:00",
      "endtime": "14:30:00"
    }
  ],
  "students": [
    {
      "studentId": 1,
      "level": 3,
      "major": "Vocal Music",
      "classification": "Senior",
      "semesters": 8,
      "userId": 1,
      "studentInstructorId": 1
    }
  ]
}
```