### PR TITLE
Add studentinstrumentId to studentinstructor

### DIFF
--- a/models/foreignkeys.js
+++ b/models/foreignkeys.js
@@ -87,12 +87,14 @@ function addForeignKeys(db) {
   students.hasMany(studentrepertoire, { as: "repertoires" });
   students.hasMany(studentinstruments, { as: "instruments" });
 
+  studentinstructor.belongsTo(studentinstruments);
   studentinstructor.belongsTo(students);
   studentinstructor.belongsTo(instructors);
 
   studentinstruments.belongsTo(instruments);
   studentinstruments.belongsTo(students);
   studentinstruments.hasMany(studentrepertoire);
+  studentinstruments.hasMany(studentinstructor);
 
   studentrepertoire.belongsTo(students);
   studentrepertoire.belongsTo(repertoire);

--- a/utils/instructor.js
+++ b/utils/instructor.js
@@ -4,6 +4,7 @@ const Instructors = db.instructors;
 const Users = db.users;
 const Availability = db.availability;
 const StudentInstructor = db.studentinstructor;
+const StudentInstruments = db.studentinstruments;
 
 exports.getAllInstructorDataForUserId = async (userId) => {
   const ins = await Instructors.findAll({
@@ -27,15 +28,19 @@ exports.getAllInstructorDataForUserId = async (userId) => {
         model: StudentInstructor,
         attributes: [["id", "studentInstructorId"]],
         include: {
-          model: Students,
-          attributes: [
-            ["id", "studentId"],
-            "level",
-            "major",
-            "classification",
-            "semesters",
-            "userId",
-          ],
+          model: StudentInstruments,
+          attributes: [["id", "studentinstrumentId"]],
+          include: {
+            model: Students,
+            attributes: [
+              ["id", "studentId"],
+              "level",
+              "major",
+              "classification",
+              "semesters",
+              "userId",
+            ],
+          },
         },
       },
     ],

--- a/utils/students.js
+++ b/utils/students.js
@@ -30,7 +30,7 @@ exports.getAllStudentDataForUserId = async (userId) => {
       {
         model: StudentInstructor,
         as: "instructors",
-        attributes: [["id", "studentinstructorId"]],
+        attributes: [["id", "studentinstructorId"], "studentinstrumentId"],
         include: {
           model: Instructors,
           attributes: [["id", "instructorId"], "title"],


### PR DESCRIPTION
Self explanatory, allows the student to select the instrument for the event signup. It'll automatically select the instructor for that instrument and filter the timeslots.

Frontend PR for this too.